### PR TITLE
remove multiple <link> nodes

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
-  var elOpenSearch = document.querySelector('[type="application/opensearchdescription+xml"]');
-  if(elOpenSearch) {
+  var elOpenSearch;
+  while(elOpenSearch = document.querySelector('[type="application/opensearchdescription+xml"]')) {
     elOpenSearch.remove();
     chrome.runtime.sendMessage("opensearch-block");
   }  


### PR DESCRIPTION
some pages, especially wordpress-based pages, have multiple <link> tags for Opensearch. The Plugin only removes the first one, leaving chrome to add a search engine.
This fixes it by adding a while loop.