### PR TITLE
update selectors

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -36,7 +36,7 @@ function spoilFormGet(elem) {
     // Autodetection requires exactly one input of type text or search
     // If the type attribute is missing, it defaults to `text`
     // Readonly inputs do not count against this total
-    if(elem.querySelectorAll(':scope input:-webkit-any([type="text" i],[type="search" i],:not([type])):not([readonly])[name]:not([name=""])').length !== 1) return;
+    if(elem.querySelectorAll(':scope input:-webkit-any([type="text" i],[type="search" i],[type*="search" i],[type=""],:not([type])):not([readonly])[name]:not([name=""])').length !== 1) return;
 
     // Autodetection also requires no password, file, or textarea elements
     if(elem.querySelector(':scope :-webkit-any(input[type="password" i],input[type="file" i],textarea)')) return;


### PR DESCRIPTION
_[Closes #26 &ndash;Ed.]_

2 selectors have been added.

`[type=""]`  is for a page where the userscript failed, but has since been fixed. It happened once, so it's a good idea to add it.

`[type*="search" i]`  could replace `[type="search" i]`, but I left the old value. It can be simplified in a future release after double-checking that the wildcard doesn't fail on some circumstances.
